### PR TITLE
Add support for deploying to Google Cloud

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.dockerignore
+Dockerfile
+.git
+.hg
+.svn

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.pyc
 dist
 tests
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# Dockerfile extending the generic Node image with application files for a
+# single application.
+FROM beta.gcr.io/google_appengine/nodejs
+# Check to see if the the version included in the base runtime satisfies \
+# >=4.1.0, if not then do an npm install of the latest available \
+# version that satisfies it. \
+RUN npm install         https://storage.googleapis.com/gae_node_packages/semver.tar.gz && \
+  (node -e 'var semver = require("semver"); \
+            if (!semver.satisfies(process.version, ">=4.1.0")) \
+              process.exit(1);' || \
+   (version=$(curl -L https://storage.googleapis.com/gae_node_packages/node_versions | \
+              node -e ' \
+                var semver = require("semver"); \
+                var http = require("http"); \
+                var spec = process.argv[1]; \
+                var latest = ""; \
+                var versions = ""; \
+                var selected_version; \
+ \
+                function verifyBinary(version) { \
+                  var options = { \
+                    "host": "storage.googleapis.com", \
+                    "method": "HEAD", \
+                    "path": "/gae_node_packages/node-" + version + \
+                            "-linux-x64.tar.gz" \
+                  }; \
+                  var req = http.request(options, function (res) { \
+                    if (res.statusCode == 404) { \
+                      console.error("Binaries for Node satisfying version " + \
+                                    version + " are not available."); \
+                      process.exit(1); \
+                    } \
+                  }); \
+                  req.end(); \
+                } \
+                function satisfies(version) { \
+                  if (semver.satisfies(version, spec)) { \
+                    process.stdout.write(version); \
+                    verifyBinary(version); \
+                    return true; \
+                  } \
+                } \
+                process.stdin.on("data", function(data) { \
+                  versions += data; \
+                }); \
+                process.stdin.on("end", function() { \
+                  versions = \
+                      versions.split("\n").sort().reverse(); \
+                  if (!versions.some(satisfies)) { \
+                    console.error("No version of Node found satisfying: " + \
+                                  spec); \
+                    process.exit(1); \
+                  } \
+                });' \
+                ">=4.1.0") && \
+                rm -rf /nodejs/* && \
+                (curl https://storage.googleapis.com/gae_node_packages/node-$version-linux-x64.tar.gz | \
+                 tar xzf - -C /nodejs --strip-components=1 \
+                 ) \
+    ) \
+   )
+COPY . /app/
+# You have to specify "--unsafe-perm" with npm install
+# when running as root.  Failing to do this can cause
+# install to appear to succeed even if a preinstall
+# script fails, and may have other adverse consequences
+# as well.
+RUN npm --unsafe-perm install
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ server with:
 $ nodemon server/app.js
 ```
 
+Alternatively, you can just run `npm monitor`. The application shell should now be available on port `8080`.
+
+### Deployment
+
+We've deployed the project to Node.js on [Google Cloud](https://cloud.google.com/nodejs/). To do the same, follow the steps in their Node.js deployment [getting started](https://cloud.google.com/nodejs/getting-started/hello-world) guide and after running `npm install` run `gcloud preview app deploy app.yaml --promote`. If everything works correctly, you should have the project deployed to your custom AppSpot endpoint. 
+
 ## Why?
 
 [Service Workers](http://www.html5rocks.com/en/tutorials/service-worker/introduction/) are fantastic for offline caching but they also offer significant  performance wins in the form of instant loading for repeat visits. This is possible with just a few changes to our overall application’s UI architecture.  

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,27 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# [START app_yaml]
+runtime: custom
+vm: true
+api_version: 1
+env_variables:
+  PORT: 8080
+
+automatic_scaling:
+  min_num_instances: 2
+  max_num_instances: 20
+  cool_down_period_sec: 60
+  cpu_utilization:
+    target_utilization: 0.5
+# [END app_yaml]

--- a/package.json
+++ b/package.json
@@ -4,21 +4,23 @@
   "private": true,
   "license": "Apache Version 2.0",
   "engines": {
-    "node": ">=0.12.7"
+    "node": ">=4.1.0"
   },
   "scripts": {
-    "start": "nodemon server/app.js"
+    "start": "node server/app.js",
+    "monitor": "nodemon server/app.js",
+    "postinstall": "gulp",
+    "deploy": "gcloud preview app deploy app.yaml --promote"
   },
   "main": "server/app.js",
   "dependencies": {
-    "express": "^4.13.3",
-    "express-handlebars": "^2.0.1"
-  },
-  "devDependencies": {
     "babel-preset-es2015": "^6.0.15",
     "babelify": "^7.2.0",
     "browserify": "^11.2.0",
     "del": "^2.0.2",
+    "express": "^4.13.3",
+    "express-handlebars": "^2.0.1",
+    "gcloud": "^0.24.1",
     "glob": "^5.0.15",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",

--- a/server/controllers/server-controller.js
+++ b/server/controllers/server-controller.js
@@ -29,8 +29,8 @@ ServerController.prototype.setUpServer = function(app) {
   app.use('/',
     express.static(path.join(__dirname + '/../../dist/')));
 
-  console.log('Starting server on 3123');
-  return app.listen('3123');
+  console.log('Starting server on 8080');
+  return app.listen('8080');
 };
 
 ServerController.prototype.addEndpoint = function(endpoint, controller) {


### PR DESCRIPTION
This set of changes enables us to push to Node.js on Cloud. I've successfully pushed app-shell to https://app-shell.appspot.com/ using this setup. Fixes #40. 

r: @gauntface 
