### PR TITLE
Hack to fix iOS 8 menu not working

### DIFF
--- a/server/views/partials/open-page.handlebars
+++ b/server/views/partials/open-page.handlebars
@@ -24,6 +24,7 @@ limitations under the License.
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta id="theme-color" name="theme-color" content="#4527A0">
 
     <link rel="manifest" href="/manifest.json">

--- a/src/scripts/view/NavDrawerView.js
+++ b/src/scripts/view/NavDrawerView.js
@@ -1,6 +1,10 @@
 export default class NavDrawerView {
 
   constructor() {
+    this.styleTransform = 'webkitTransform';
+    if (!(this.styleTransform in document.documentElement.style)) {
+      this.styleTransform = 'transform';
+    }
     this.rootElement = document.querySelector('.js-side-nav');
     this.sideNavContent = this.rootElement
       .querySelector('.js-side-nav-content');
@@ -20,7 +24,7 @@ export default class NavDrawerView {
         e.preventDefault();
       }
 
-      this.sideNavContent.style.transform =
+      this.sideNavContent.style[this.styleTransform] =
         'translateX(' + sideNavTransform + 'px)';
     };
 
@@ -58,7 +62,7 @@ export default class NavDrawerView {
   close() {
     this.rootElement.classList.remove('side-nav--visible');
     this.sideNavContent.classList.add('side-nav__content--animatable');
-    this.sideNavContent.style.transform = 'translateX(-102%)';
+    this.sideNavContent.style[this.styleTransform] = 'translateX(-102%)';
   }
 
   open() {
@@ -80,7 +84,7 @@ export default class NavDrawerView {
           onSideNavTransitionEnd);
 
     requestAnimationFrame( () => {
-      this.sideNavContent.style.transform = 'translateX(0px)';
+      this.sideNavContent.style[this.styleTransform] = 'translateX(0px)';
     });
   }
 


### PR DESCRIPTION
After debugging and experimenting different approaches this hack made the navigation menu work on iOS 8.
I belleve it'll not cause any problem on other browsers, tested on chrome/firefox/safari/iOS 8.
