### PR TITLE
Seperate ports for production and dev

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,3 +22,4 @@ serverController.addEndpoint('/api*', new APIController(
 ));
 // The static page controller serves the basic form of the pages
 serverController.addEndpoint('/*', new StaticPageController());
+serverController.startServer(process.env.PORT);

--- a/gulp-tasks/nodemon.js
+++ b/gulp-tasks/nodemon.js
@@ -3,13 +3,9 @@ var nodemon = require('gulp-nodemon');
 var env = require('gulp-env');
 
 gulp.task('nodemon', function() {
-  const PROD_PORT = 8080;
-  const DEV_PORT = 8081;
-  // This results in different ports for prod and dev
-  var port = (GLOBAL.config.env === 'prod') ? PROD_PORT : DEV_PORT;
   env({
     vars: {
-      PORT: port
+      PORT: GLOBAL.config.port
     }
   });
 

--- a/gulp-tasks/nodemon.js
+++ b/gulp-tasks/nodemon.js
@@ -1,7 +1,18 @@
 var gulp = require('gulp');
 var nodemon = require('gulp-nodemon');
+var env = require('gulp-env');
 
 gulp.task('nodemon', function() {
+  const PROD_PORT = 8080;
+  const DEV_PORT = 8081;
+  // This results in different ports for prod and dev
+  var port = (GLOBAL.config.env === 'prod') ? PROD_PORT : DEV_PORT;
+  env({
+    vars: {
+      PORT: port
+    }
+  });
+
   return nodemon({
     script: 'app.js'
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,7 @@ require('require-dir')('gulp-tasks');
 var projectPackage = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 GLOBAL.config = {
   env: 'prod',
+  port: 8080,
   src: 'src',
   dest: 'dist',
   version: projectPackage.version,
@@ -67,6 +68,7 @@ function startWatchTasks() {
 
 gulp.task('dev', function() {
   GLOBAL.config.env = 'dev';
+  GLOBAL.config.port = 8081;
   return startWatchTasks();
 });
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-bump": "^1.0.0",
+    "gulp-env": "^0.2.0",
     "gulp-eslint": "^1.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.3.0",

--- a/server/controllers/server-controller.js
+++ b/server/controllers/server-controller.js
@@ -9,10 +9,24 @@ function ServerController() {
     layoutsDir: path.join(__dirname, '/../views/layouts'),
     partialsDir: path.join(__dirname, '/../views/partials')
   });
-  var expressServer = this.setUpServer(expressApp, handleBarsInstance);
+
+  // Set up the use of handle bars and set the path for views and layouts
+  expressApp.set('views', path.join(__dirname, '/../views'));
+  expressApp.engine('handlebars', handleBarsInstance.engine);
+  expressApp.set('view engine', 'handlebars');
+
+  // Define static assets path - i.e. styles, scripts etc.
+  expressApp.use('/',
+    express.static(path.join(__dirname + '/../../dist/')));
+
+  var expressServer = null;
 
   this.getExpressApp = function() {
     return expressApp;
+  };
+
+  this.setExpressServer = function(server) {
+    expressServer = server;
   };
 
   this.getExpressServer = function() {
@@ -24,18 +38,12 @@ function ServerController() {
   };
 }
 
-ServerController.prototype.setUpServer = function(app, handleBarsInstance) {
-  // Set up the use of handle bars and set the path for views and layouts
-  app.set('views', path.join(__dirname, '/../views'));
-  app.engine('handlebars', handleBarsInstance.engine);
-  app.set('view engine', 'handlebars');
-
-  // Define static assets path - i.e. styles, scripts etc.
-  app.use('/',
-    express.static(path.join(__dirname + '/../../dist/')));
-
-  console.log('Starting server on 8080');
-  return app.listen('8080');
+ServerController.prototype.startServer = function(port) {
+  var server = this.getExpressApp().listen(port, () => {
+    var serverPort = server.address().port;
+    console.log('Server running on port ' + serverPort);
+  });
+  this.setExpressServer(server);
 };
 
 ServerController.prototype.addEndpoint = function(endpoint, controller) {

--- a/server/controllers/server-controller.js
+++ b/server/controllers/server-controller.js
@@ -39,6 +39,13 @@ function ServerController() {
 }
 
 ServerController.prototype.startServer = function(port) {
+  // As a failsafe use port 0 if the input isn't defined
+  // this will result in a random port being assigned
+  // See : https://nodejs.org/api/http.html for details
+  if (typeof port === 'undefined' || port === null) {
+    port = 0;
+  }
+
   var server = this.getExpressApp().listen(port, () => {
     var serverPort = server.address().port;
     console.log('Server running on port ' + serverPort);

--- a/server/controllers/server-controller.js
+++ b/server/controllers/server-controller.js
@@ -42,7 +42,11 @@ ServerController.prototype.startServer = function(port) {
   // As a failsafe use port 0 if the input isn't defined
   // this will result in a random port being assigned
   // See : https://nodejs.org/api/http.html for details
-  if (typeof port === 'undefined' || port === null) {
+  if (
+    typeof port === 'undefined' ||
+    port === null ||
+    isNaN(parseInt(port, 10))
+  ) {
     port = 0;
   }
 


### PR DESCRIPTION
As per #64 idea, PR to do exactly that.

I've avoided a random port for dev server simply because nodemon will restart the server and having a random port assigned each time sounds like a pain to me.

cc @addyosmani @jeffposnick 
