### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.0.15",
     "babelify": "^7.2.0",
-    "browserify": "^11.2.0",
+    "browserify": "^12.0.0",
     "del": "^2.0.2",
     "express": "^4.13.3",
     "express-handlebars": "^2.0.1",


### PR DESCRIPTION
application-shell is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `browserify`

This PR fixes the ReDoS vulnerability by upgrading `browserify` to version 12.0.0 This upgrade will also fix the following other vulnerabilities:
- [Command Injection vulnerabilty](https://snyk.io/vuln/npm:shell-quote:20160621) in the `shell-quote` dependency.

Check out the [Snyk test report](https://snyk.io/test/github/googlechrome/application-shell) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
